### PR TITLE
chore(update): update akka-http and google-api-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ crossScalaVersions := Seq(scalaVersion.value, "2.11.8", "2.12.4")
 sonatypeProfileName := "com.gu"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"           %%  "akka-http"         % "10.1.13",
-  "com.google.api-client"       %   "google-api-client" % "1.31.1",
+  "com.typesafe.akka"           %%  "akka-http"         % "10.1.15",
+  "com.google.api-client"       %   "google-api-client" % "1.35.0",
   "com.typesafe.scala-logging"  %%  "scala-logging"     % "3.9.2"
 )
 

--- a/src/main/scala/com/gu/identity/social/google/GoogleOpenIDConnect.scala
+++ b/src/main/scala/com/gu/identity/social/google/GoogleOpenIDConnect.scala
@@ -2,7 +2,7 @@ package com.gu.identity.social.google
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.http.javanet.NetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.gu.identity.social.Google
 import com.gu.identity.social.SocialAuthErrors.{AuthError, MissingScope, TokenVerificationFailed}
 import com.gu.identity.social.jwt.IDToken
@@ -18,7 +18,7 @@ object GoogleOpenIDConnect {
     verifyToken(idToken, googleClientID)
 
   def verifyToken(idToken: IDToken, googleClientID: GoogleClientID): Either[AuthError, JWTUser] = {
-    val verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport, JacksonFactory.getDefaultInstance)
+    val verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport, GsonFactory.getDefaultInstance)
       .setAudience(List(googleClientID.id).asJavaCollection)
       .setIssuer("https://accounts.google.com")
       .build();


### PR DESCRIPTION
## What does this change?

Updates akka-http and google-api-client.
Akka was no problem.
google-api-client had a small change, JacksonFactory was deprecated, GsonFactory seems to be the replacement, based on this comment:
https://stackoverflow.com/a/66250911

## How to test

This is a standalone library, but only has one usage, it needs to be updated and used by identity-api here:
https://github.com/guardian/identity/blob/3877e5b8cf0fb1f7aeab450b60c59a87e173b3f8/identity-api/build.sbt#L31

## How can we measure success?

New release done successfully, identity-api updated to use new version, and working correctly and released to prod.